### PR TITLE
fix: sync node proxy mode from Clash API on mount

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3842,6 +3842,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -33,7 +33,7 @@ serde_yaml = "0.9"
 
 # Tauri 2.0 最新版本
 tauri = { version = "2.10.2", features = ["tray-icon", "unstable", "devtools"] }
-reqwest = { version = "0.12", features = ["json", "stream", "native-tls-vendored"] }
+reqwest = { version = "0.12", features = ["json", "stream", "native-tls-vendored", "blocking"] }
 dirs = "5.0.1"
 tokio = { version = "1.48", features = ["full"] }
 futures-util = "0.3"

--- a/src-tauri/src/app/network/subscription_service/mode.rs
+++ b/src-tauri/src/app/network/subscription_service/mode.rs
@@ -6,7 +6,64 @@ use std::fs::File;
 use std::io::{Read, Write};
 use std::path::Path;
 use tauri::AppHandle;
-use tracing::{error, info};
+use tracing::{error, info, warn};
+
+/// Read the Clash API port from a config file's experimental.clash_api.external_controller
+fn read_api_port_from_config(config_path: &Path) -> Option<u16> {
+    let mut file = File::open(config_path).ok()?;
+    let mut content = String::new();
+    file.read_to_string(&mut content).ok()?;
+    let json: serde_json::Value = serde_json::from_str(&content).ok()?;
+    let controller = json
+        .get("experimental")?
+        .get("clash_api")?
+        .get("external_controller")?
+        .as_str()?;
+    // Parse "127.0.0.1:12081" -> 12081
+    controller.rsplit(':').next()?.parse::<u16>().ok()
+}
+
+/// Patch the running Clash API mode via HTTP PATCH /configs
+fn patch_clash_api_mode(api_port: u16, mode: &str) -> Result<(), Box<dyn Error>> {
+    let url = format!("http://127.0.0.1:{}/configs", api_port);
+    let body = format!(r#"{{"mode":"{}"}}"#, mode);
+
+    let client = reqwest::blocking::Client::builder()
+        .timeout(std::time::Duration::from_secs(3))
+        .no_proxy()
+        .build()?;
+
+    let resp = client
+        .patch(&url)
+        .header("Content-Type", "application/json")
+        .body(body)
+        .send()?;
+
+    if resp.status().is_success() {
+        info!("Clash API mode patched to: {}", mode);
+        Ok(())
+    } else {
+        Err(format!("Clash API returned status {}", resp.status()).into())
+    }
+}
+
+/// Query the running Clash API mode via HTTP GET /configs
+fn query_clash_api_mode(api_port: u16) -> Result<String, Box<dyn Error>> {
+    let url = format!("http://127.0.0.1:{}/configs", api_port);
+
+    let client = reqwest::blocking::Client::builder()
+        .timeout(std::time::Duration::from_secs(3))
+        .no_proxy()
+        .build()?;
+
+    let resp = client.get(&url).send()?;
+    let json: serde_json::Value = resp.json()?;
+    if let Some(mode) = json.get("mode").and_then(|m| m.as_str()) {
+        Ok(mode.to_string())
+    } else {
+        Err("mode field not found in Clash API response".into())
+    }
+}
 
 pub async fn toggle_proxy_mode_impl(app_handle: AppHandle, mode: String) -> Result<String, String> {
     if !["global", "rule"].contains(&mode.as_str()) {
@@ -29,28 +86,65 @@ pub async fn toggle_proxy_mode_impl(app_handle: AppHandle, mode: String) -> Resu
         return Err("配置文件不存在，请先添加订阅".to_string());
     }
 
+    // 1. Update the config file (for persistence across restarts)
     match modify_default_mode(&path, mode.clone(), None) {
         Ok(_) => {
-            info!("代理模式已切换为: {}", mode);
-            Ok(format!("代理模式已切换为: {}", mode))
+            info!("配置文件代理模式已更新为: {}", mode);
         }
         Err(e) => {
-            error!("切换代理模式失败: {}", e);
-            Err(format!("切换代理模式失败: {}", e))
+            error!("更新配置文件代理模式失败: {}", e);
+            return Err(format!("切换代理模式失败: {}", e));
         }
     }
+
+    // 2. Also update config.json if it's different from active config
+    let config_json_path = paths::get_config_dir().join("config.json");
+    if config_json_path.exists() && config_json_path != path {
+        if let Err(e) = modify_default_mode(&config_json_path, mode.clone(), None) {
+            warn!("更新 config.json 代理模式失败 (非致命): {}", e);
+        }
+    }
+
+    // 3. Patch the running Clash API to switch mode immediately
+    let api_port = read_api_port_from_config(&path)
+        .or_else(|| read_api_port_from_config(&config_json_path))
+        .unwrap_or(app_config.api_port as u16);
+
+    match patch_clash_api_mode(api_port, &mode) {
+        Ok(_) => {
+            info!("Clash API 代理模式已实时切换为: {}", mode);
+        }
+        Err(e) => {
+            warn!("Clash API 实时切换失败 (配置文件已更新，重启后生效): {}", e);
+        }
+    }
+
+    Ok(format!("代理模式已切换为: {}", mode))
 }
 
 pub fn get_current_proxy_mode_impl() -> Result<String, String> {
     info!("正在获取当前代理模式");
 
-    let path = paths::get_config_dir().join("config.json");
+    // 1. Try to get the live mode from Clash API first (most accurate)
+    let config_path = paths::get_config_dir().join("config.json");
+    if let Some(api_port) = read_api_port_from_config(&config_path) {
+        match query_clash_api_mode(api_port) {
+            Ok(mode) => {
+                info!("从 Clash API 获取当前代理模式: {}", mode);
+                return Ok(mode);
+            }
+            Err(e) => {
+                warn!("从 Clash API 获取模式失败，回退到配置文件: {}", e);
+            }
+        }
+    }
 
-    if !path.exists() {
+    // 2. Fall back to reading from config file
+    if !config_path.exists() {
         return Ok("rule".to_string());
     }
 
-    match read_proxy_mode_from_config(&path) {
+    match read_proxy_mode_from_config(&config_path) {
         Ok(mode) => {
             info!("当前代理模式为: {}", mode);
             Ok(mode)

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -188,6 +188,7 @@ import TrafficChart from '@/components/layout/TrafficChart.vue'
 import { useKernelStatus } from '@/composables/useKernelStatus'
 import { useSudoStore } from '@/stores'
 import { formatBytes, formatSpeed } from '@/utils'
+import { proxyService } from '@/services/proxy-service'
 
 defineOptions({
   name: 'HomeView',
@@ -525,6 +526,16 @@ onMounted(async () => {
   }
   checkAdmin()
   await kernelStore.initializeStore()
+
+  // Sync node proxy mode from actual Clash API state
+  try {
+    const mode = await proxyService.getCurrentProxyMode()
+    if (mode === 'global' || mode === 'rule') {
+      currentNodeProxyMode.value = mode
+    }
+  } catch {
+    // keep default 'rule' if API not ready
+  }
 })
 </script>
 


### PR DESCRIPTION
## Problem

\currentNodeProxyMode\ in \HomeView.vue\ is hardcoded to \'rule'\ on component mount. This causes the UI to always display **Rule Mode** regardless of the actual Clash API mode.

When the mode is set to \global\ (via API, config \default_mode\, or previous user action), the UI still shows \ule\ — misleading users and potentially causing mode resets.

## Root Cause

In \HomeView.vue\:
\\\	ypescript
const currentNodeProxyMode = ref('rule')  // hardcoded default
\\\

The \onMounted\ hook never fetches the actual mode from the backend.

## Fix

Added a call to \proxyService.getCurrentProxyMode()\ in \onMounted\ to sync the UI with the actual Clash API state:

\\\	ypescript
const mode = await proxyService.getCurrentProxyMode()
if (mode === 'global' || mode === 'rule') {
  currentNodeProxyMode.value = mode
}
\\\

Falls back to \'rule'\ if the API is not ready yet.

## Testing

- Set mode to \global\ via Clash API
- Restart sing-box-windows
- UI now correctly shows **Global Mode** on startup
- Switching between global/rule works correctly in both directions