### PR TITLE
feat(ci): add Windows ARM64 build target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,9 @@ jobs:
           - os: macos-15-intel
             target: x86_64-apple-darwin
             name: macos-intel
+          - os: windows-latest
+            target: aarch64-pc-windows-msvc
+            name: windows-arm64
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -64,6 +67,9 @@ jobs:
         uses: swatinem/rust-cache@v2
         with:
           workspaces: './src-tauri -> target'
+      - name: install rust target
+        if: matrix.target == 'aarch64-pc-windows-msvc'
+        run: rustup target add aarch64-pc-windows-msvc
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -120,7 +126,7 @@ jobs:
           fi
 
       - name: Create Windows portable zip
-        if: matrix.os == 'windows-latest'
+        if: contains(matrix.name, 'windows') # Run for all Windows architectures
         shell: pwsh
         run: |
           $exePath = "src-tauri/target/${{ matrix.target }}/release/sing-box-windows.exe"
@@ -160,7 +166,13 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: windows-artifacts
-          path: windows-artifacts/
+          path: windows-artifacts/x64/
+
+      - name: Download Windows ARM64 artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: windows-arm64-artifacts
+          path: windows-artifacts/arm64/
 
       - name: Download Linux artifacts
         uses: actions/download-artifact@v4
@@ -210,9 +222,9 @@ jobs:
           tag_name: ${{ steps.tag.outputs.tag }}
           body: ${{ steps.extract_notes.outputs.release_notes }}
           files: |
-            windows-artifacts/msi/*.msi
-            windows-artifacts/nsis/*.exe
-            windows-artifacts/portable/sing-box-windows-portable.zip
+            windows-artifacts/**/*.msi
+            windows-artifacts/**/*.exe
+            windows-artifacts/**/*.zip
             linux-artifacts/appimage/sing-box-windows_*.AppImage*
             linux-artifacts/deb/sing-box-windows_*.deb*
             linux-artifacts/rpm/*.rpm

--- a/scripts/kernel-targets.mjs
+++ b/scripts/kernel-targets.mjs
@@ -8,6 +8,12 @@ const KERNEL_TARGETS = Object.freeze([
     tauriTarget: 'x86_64-pc-windows-msvc'
   },
   {
+    platform: 'windows',
+    arch: 'arm64',
+    executable: 'sing-box.exe',
+    tauriTarget: 'aarch64-pc-windows-msvc'
+  },
+  {
     platform: 'linux',
     arch: 'amd64',
     executable: 'sing-box',


### PR DESCRIPTION
## Summary

Add Windows ARM64 (arch64-pc-windows-msvc) as a build target in the release workflow.

## Changes

- **New build matrix**: windows-arm64 using arch64-pc-windows-msvc target on windows-latest runner
- **Conditional Rust toolchain**: ustup target add aarch64-pc-windows-msvc runs only for the ARM64 matrix entry, avoiding unnecessary steps on other platforms
- **Fixed portable zip step**: Changed condition from matrix.os == 'windows-latest' to contains(matrix.name, 'windows') so both x64 and ARM64 Windows builds get a portable zip
- **Split artifact download paths**: x64 artifacts go to \windows-artifacts/x64/\, ARM64 to \windows-artifacts/arm64/\
- **Glob release patterns**: Updated file upload globs to \windows-artifacts/**/*.msi\, \**/*.exe\, \**/*.zip\ to include both architectures

## Result

The release will include ARM64 Windows installers (.msi, .exe) alongside the existing x64 packages.