### PR TITLE
fix(parser): complete hysteria2 parsing for URI and Clash subscriptions

### DIFF
--- a/src-tauri/src/app/network/subscription_service/parser.rs
+++ b/src-tauri/src/app/network/subscription_service/parser.rs
@@ -512,6 +512,23 @@ fn convert_clash_node_to_singbox(clash_node: &Value) -> Option<Value> {
                 node["down_mbps"] = json!(down);
             }
 
+            // Clash hysteria2 的 salamander 混淆：obfs / obfs-password
+            if let Some(obfs_type) = clash_node
+                .get("obfs")
+                .and_then(|o| o.as_str())
+                .filter(|s| !s.is_empty())
+            {
+                let mut obfs = json!({ "type": obfs_type });
+                if let Some(obfs_password) = clash_node
+                    .get("obfs-password")
+                    .and_then(|p| p.as_str())
+                    .filter(|s| !s.is_empty())
+                {
+                    obfs["password"] = json!(obfs_password);
+                }
+                node["obfs"] = obfs;
+            }
+
             Some(node)
         }
         "tuic" => {
@@ -947,14 +964,65 @@ fn parse_hysteria2_uri(uri: &str) -> Option<Value> {
         tls["alpn"] = alpn;
     }
 
-    Some(json!({
+    let mut node = json!({
         "tag": tag,
         "type": "hysteria2",
         "server": server,
         "server_port": server_port,
         "password": password,
         "tls": tls
-    }))
+    });
+
+    // Parse optional hysteria2 obfuscation (salamander) parameters:
+    //   obfs=<type>&obfs-password=<password>
+    if let Some(obfs_type) = query
+        .get("obfs")
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+    {
+        let mut obfs = serde_json::Map::new();
+        obfs.insert("type".to_string(), json!(obfs_type));
+        if let Some(obfs_password) = query
+            .get("obfs-password")
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty())
+        {
+            obfs.insert("password".to_string(), json!(obfs_password));
+        }
+        node["obfs"] = json!(obfs);
+    }
+
+    // upmbps/downmbps 是 hysteria2 URI 的客户端带宽声明（MBps）
+    if let Some(up) = query.get("upmbps").and_then(|s| s.trim().parse::<u64>().ok()) {
+        node["up_mbps"] = json!(up);
+    }
+    if let Some(down) = query.get("downmbps").and_then(|s| s.trim().parse::<u64>().ok()) {
+        node["down_mbps"] = json!(down);
+    }
+
+    // fastopen 参数（0/1）
+    if let Some(fast_open) = query
+        .get("fastopen")
+        .map(|s| s.as_str())
+        .and_then(parse_boolish)
+    {
+        node["tcp_fast_open"] = json!(fast_open);
+    }
+
+    // mport 多端口参数（逗号分隔），映射到 server_ports
+    if let Some(mport) = query.get("mport").map(|s| s.trim()).filter(|s| !s.is_empty()) {
+        let ports: Vec<Value> = mport
+            .split(',')
+            .map(|p| p.trim())
+            .filter(|p| !p.is_empty())
+            .map(|p| Value::String(p.to_string()))
+            .collect();
+        if !ports.is_empty() {
+            node["server_ports"] = json!(ports);
+        }
+    }
+
+    Some(node)
 }
 
 fn parse_tuic_uri(uri: &str) -> Option<Value> {

--- a/src-tauri/src/app/network/subscription_service/parser.tests.rs
+++ b/src-tauri/src/app/network/subscription_service/parser.tests.rs
@@ -87,6 +87,32 @@ fn parse_uri_list_hysteria2() {
 }
 
 #[test]
+fn parse_uri_list_hysteria2_with_obfs() {
+    let content = concat!(
+        "hysteria2://password123@example.com:443",
+        "?obfs=salamander&obfs-password=obfs-secret",
+        "&sni=example.com&alpn=h3,h2,http/1.1",
+        "&insecure=0&upmbps=100&downmbps=200",
+        "&fastopen=1&mport=443,8443#hy2-obfs"
+    );
+    let nodes = extract_nodes_from_subscription(content).expect("should parse");
+    assert_eq!(nodes.len(), 1);
+    assert_eq!(nodes[0]["type"].as_str().unwrap(), "hysteria2");
+    assert_eq!(nodes[0]["password"].as_str().unwrap(), "password123");
+    assert_eq!(nodes[0]["server"].as_str().unwrap(), "example.com");
+    assert_eq!(nodes[0]["server_port"].as_u64().unwrap(), 443);
+    assert_eq!(nodes[0]["tls"]["server_name"].as_str().unwrap(), "example.com");
+    assert_eq!(nodes[0]["tls"]["alpn"][0].as_str().unwrap(), "h3");
+    assert_eq!(nodes[0]["obfs"]["type"].as_str().unwrap(), "salamander");
+    assert_eq!(nodes[0]["obfs"]["password"].as_str().unwrap(), "obfs-secret");
+    assert_eq!(nodes[0]["up_mbps"].as_u64().unwrap(), 100);
+    assert_eq!(nodes[0]["down_mbps"].as_u64().unwrap(), 200);
+    assert!(nodes[0]["tcp_fast_open"].as_bool().unwrap());
+    assert_eq!(nodes[0]["server_ports"][0].as_str().unwrap(), "443");
+    assert_eq!(nodes[0]["server_ports"][1].as_str().unwrap(), "8443");
+}
+
+#[test]
 fn parse_uri_list_tuic_basic() {
     let content = "tuic://2DD61D93-75D8-4DA4-AC0E-6AECE7EAC365:hello@example.com:10443#TUIC";
     let nodes = extract_nodes_from_subscription(content).expect("should parse");
@@ -239,6 +265,8 @@ proxies:
     down: 50
     skip-cert-verify: true
     password: "secret-pass"
+    obfs: salamander
+    obfs-password: "obfs-secret-pass"
 "#;
     let nodes = extract_nodes_from_subscription(yaml).expect("should parse");
     assert_eq!(nodes.len(), 1);
@@ -254,6 +282,8 @@ proxies:
     assert!(nodes[0]["tls"]["insecure"].as_bool().unwrap());
     assert_eq!(nodes[0]["up_mbps"].as_u64().unwrap(), 50);
     assert_eq!(nodes[0]["down_mbps"].as_u64().unwrap(), 50);
+    assert_eq!(nodes[0]["obfs"]["type"].as_str().unwrap(), "salamander");
+    assert_eq!(nodes[0]["obfs"]["password"].as_str().unwrap(), "obfs-secret-pass");
 }
 
 #[test]


### PR DESCRIPTION
parse_hysteria2_uri previously dropped obfs/obfs-password, upmbps/downmbps, fastopen and mport query parameters, and the Clash hysteria2 branch ignored obfs/obfs-password entirely. Hysteria2 nodes with salamander obfuscation (or bandwidth/port options) imported from subscriptions ended up without those fields and could not connect.

- hysteria2 URI: parse obfs/obfs-password, upmbps/downmbps, fastopen, mport
- Clash hysteria2: parse obfs/obfs-password
- extend unit tests for both import paths